### PR TITLE
Import prescription data into MongoDB

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN git config --global core.editor "code --wait"
 ARG SHELLCHECK_VERSION="v0.7.1"
 ARG SECRETHUB_CLI_VERSION="v0.40.0"
 ARG MONGO_SHELL_VERSION="4.4.0"
+ARG MONGODB_TOOLS_VERSION="100.1.1"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"] 
 # hadolint ignore=DL4001
 RUN apt-get update \
@@ -34,6 +35,11 @@ RUN apt-get update \
     && install -m 755 /tmp/mongodb_shell/mongodb-linux-x86_64-debian10-${MONGO_SHELL_VERSION}/bin/mongo /usr/local/bin/mongo \
     && rm -rf /tmp/mongodb_shell \
     #
+    # Install Mongo database tools - needed for JSON import
+    && mkdir -p /tmp/mongodb_tools \
+    && wget -qO- "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian10-x86_64-${MONGODB_TOOLS_VERSION}.tgz" | tar -xz -C /tmp/mongodb_tools/ \
+    && install -m 755 /tmp/mongodb_tools/mongodb-database-tools-debian10-x86_64-${MONGODB_TOOLS_VERSION}/bin/mongoimport /usr/local/bin/mongoimport \
+    && rm -rf /tmp/mongodb_tools \
     # Install the Confluent Cloud CLI - see:
     # https://docs.confluent.io/current/quickstart/cloud-quickstart/index.html#cloud-cli-install
     && curl -L --http1.1 https://cnfl.io/ccloud-cli | sh -s -- -b /usr/local/bin \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@ RUN git config --global core.editor "code --wait"
     # https://askubuntu.com/a/1228181)
 ARG SHELLCHECK_VERSION="v0.7.1"
 ARG SECRETHUB_CLI_VERSION="v0.40.0"
+ARG MONGO_SHELL_VERSION="4.4.0"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"] 
 # hadolint ignore=DL4001
 RUN apt-get update \
@@ -27,6 +28,12 @@ RUN apt-get update \
     && wget -qO- "https://github.com/secrethub/secrethub-cli/releases/download/${SECRETHUB_CLI_VERSION}/secrethub-${SECRETHUB_CLI_VERSION}-linux-386.tar.gz" | tar -xz -C /tmp/secrethub/ \
     && install -m 755 /tmp/secrethub/bin/secrethub /usr/local/bin/secrethub \
     && rm -rf /tmp/secrethub \
+    # Install Mongo shell
+    && mkdir -p /tmp/mongodb_shell \
+    && wget -qO- "https://downloads.mongodb.org/linux/mongodb-shell-linux-x86_64-debian10-${MONGO_SHELL_VERSION}.tgz" | tar -xz -C /tmp/mongodb_shell/ \
+    && install -m 755 /tmp/mongodb_shell/mongodb-linux-x86_64-debian10-${MONGO_SHELL_VERSION}/bin/mongo /usr/local/bin/mongo \
+    && rm -rf /tmp/mongodb_shell \
+    #
     # Install the Confluent Cloud CLI - see:
     # https://docs.confluent.io/current/quickstart/cloud-quickstart/index.html#cloud-cli-install
     && curl -L --http1.1 https://cnfl.io/ccloud-cli | sh -s -- -b /usr/local/bin \

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,27 @@
 
 ## Running the app locally
 
+---
+
+### IDE (Integrated Development Environment) setup
+
+#### Visual Studio Code
+
+The easiest way to set up your development environment (unless you have [Codespaces](https://github.com/features/codespaces/), which is even easier) is to use [Visual Studio Code](https://code.visualstudio.com/)'s [Remote Containers](https://code.visualstudio.com/docs/remote/containers) functionality:
+  * [System requirements](https://code.visualstudio.com/docs/remote/containers#_system-requirements)
+  * Checkout the `british-prescription-data` project if you are a collaborator on the project
+  * Or [Fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks) if you are not
+  * [Open the local project folder in a container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
+  * Everything will then be setup for you.
+
+
+#### Codespaces
+
+If you have access to [GitHub Codespaces](https://github.com/features/codespaces/) (which allows full remote
+development from within your browser) then all you need to do is [open this repository in Codespaces](https://github.com/codespaces) - easy!
+
+---
+
 ### Prerequisites
 
 - A [Confluent Cloud](https://www.confluent.io/confluent-cloud) account 
@@ -47,25 +68,9 @@
   2. run this script from the root folder of the project:
      - `./scripts/add-mongodb-details-to-secrethub.sh`
   
+---
 
-
-### Visual Studio Code
-
-The easiest way to set up your development environment (unless you have [Codespaces](https://github.com/features/codespaces/), which is even easier) is to use [Visual Studio Code](https://code.visualstudio.com/)'s [Remote Containers](https://code.visualstudio.com/docs/remote/containers) functionality:
-  * [System requirements](https://code.visualstudio.com/docs/remote/containers#_system-requirements)
-  * Checkout the `british-prescription-data` project if you are a collaborator on the project
-  * Or [Fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks) if you are not
-  * [Open the local project folder in a container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
-  * Everything will then be setup for you.
-
-
-### Codespaces
-
-If you have access to [GitHub Codespaces](https://github.com/features/codespaces/) (which allows full remote
-development from within your browser) then all you need to do is [open this repository in Codespaces](https://github.com/codespaces) - easy!
-
-
-### Importing the prescription data
+### Importing the prescription data into MongoDB
 
 - NB you only need to run `secrethub init` once on your development machine (or Codespace):
 
@@ -74,4 +79,6 @@ development from within your browser) then all you need to do is [open this repo
 - Now run this script from the root folder of the project:
 
   `./scripts/secrethub-wrapper.sh`
+
+---
   

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,14 +33,13 @@
      - Choose **`Allow access from anywhere`**
   8. Choose **`Connect to your cluster`** on the `Get Started` green helper menu
      - Choose **`Connect with the mongo shell`**
-     - **Copy the connection string** and modify it as follows:
-       - Just keep the bit between the quotes, removing the quotes and also removing`/<dbname>` at the end
+     - Copy just the MongoDB host name from the Connection
          
-         i.e. the bit you retain should look like this:
+         i.e. copy just the bit that looks like this:
          
-         `mongodb+srv://british-prescription-da.xxxxx.mongodb.net`
+         `british-prescription-da.xxxxx.mongodb.net`
          
-         Save this connection string somewhere temporarily
+         Save this MongoDB host name somewhere temporarily (you will add it to SecretHub in the next step)
 
 - Add your MongoDB details to SecretHub
   1. Log in to SecretHub if you are not already logged in:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 
 - A [Confluent Cloud](https://www.confluent.io/confluent-cloud) account 
 (3 month free trial when you signup)
+  
 
 - A [SecretHub](https://secrethub.io/) account:
   - [Install the SecretHub CLI](https://secrethub.io/docs/reference/cli/install/) - or open this repository in a [Codespace](https://github.com/features/codespaces/), which has the CLI pre-installed
@@ -16,6 +17,24 @@
     - `secrethub credential backup` 
   - Ask a [core maintainer of this project](CODEOWNERS) to be added to the project's SecretHub org, giving them your SecretHub username.
     - You must wait for the core maintainer to confirm that you are set up on the SecretHub org before you can proceed.
+
+
+- A [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) cloud account (free plan)
+  1. **[Sign up for a new account](https://www.mongodb.com/try)** if you do not already have one
+  2. Choose the **free tier**
+  3. **Create a cluster** as prompted and name it **`british-prescription-data`**
+     - Wait for the cluster to be created (takes a few minutes)
+  4. Click on the `Get Started` green helper link on the bottom left
+  5. Choose **`Create your first database user`**
+  6. Enter **`developer`** as the user name
+     - For the password, choose **`Autogenerate Secure Password`**, then copy and save it
+     - all the other defaults are fine, no need to change them
+  7. Choose **`Whitelist your IP address`** on the `Get Started` green helper menu
+     - Choose **`Allow access from anywhere`**
+  8. Choose **`Connect to your cluster`** on the `Get Started` green helper menu
+     - Choose **`Connect with the mongo shell`**
+     - **Copy the connection string** and save it somewhere
+  
 
 
 ### Visual Studio Code

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,12 +47,13 @@ development from within your browser) then all you need to do is [open this repo
      - Wait for the cluster to be created (takes a few minutes)
   4. Click on the `Get Started` green helper link on the bottom left
   5. Choose **`Create your first database user`**
-  6. Enter **`developer`** as the user name
+  6. Keep to the default Authentication Method choice as `Password`
+  7. Enter **`developer`** as the user name
      - For the password, choose **`Autogenerate Secure Password`**, then copy and save it
      - all the other defaults are fine, no need to change them
-  7. Choose **`Whitelist your IP address`** on the `Get Started` green helper menu
+  8. Choose **`Whitelist your IP address`** on the `Get Started` green helper menu
      - Choose **`Allow access from anywhere`**
-  8. Choose **`Connect to your cluster`** on the `Get Started` green helper menu
+  9. Choose **`Connect to your cluster`** on the `Get Started` green helper menu
      - Choose **`Connect with the mongo shell`**
      - Copy just the MongoDB host name from the Connection
          

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,20 @@
      - Choose **`Allow access from anywhere`**
   8. Choose **`Connect to your cluster`** on the `Get Started` green helper menu
      - Choose **`Connect with the mongo shell`**
-     - **Copy the connection string** and save it somewhere
+     - **Copy the connection string** and modify it as follows:
+       - Just keep the bit between the quotes, removing the quotes and also removing`/<dbname>` at the end
+         
+         i.e. the bit you retain should look like this:
+         
+         `mongodb+srv://british-prescription-da.xxxxx.mongodb.net`
+         
+         Save this connection string somewhere temporarily
+
+- Add your MongoDB details to SecretHub
+  1. Log in to SecretHub if you are not already logged in:
+     - `secrethub init --backup-code <your-secrethub-credential>`
+  2. run this script from the root folder of the project:
+     - `./scripts/add-mongodb-details-to-secrethub.sh`
   
 
 

--- a/.github/workflows/check_commit_message.yml
+++ b/.github/workflows/check_commit_message.yml
@@ -21,4 +21,4 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.1.2
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'suppress, notify, download'
+          additional-verbs: 'suppress, notify, download, import'

--- a/scripts/add-mongodb-details-to-secrethub.sh
+++ b/scripts/add-mongodb-details-to-secrethub.sh
@@ -9,9 +9,9 @@ REPO_NAME=british-prescription-data
 ORG_AND_REPO="$ORG_NAME"/"$REPO_NAME"
 COLLABORATOR_DIR="$ORG_AND_REPO"/"$SECRETHUB_COLLABORATOR"
 
-echo -n "Enter the MongoDB connection string you noted down earlier: "
-read -r SECRETHUB_MONGODB_CONNECTION_STRING
-echo "$SECRETHUB_MONGODB_CONNECTION_STRING" | secrethub write "$COLLABORATOR_DIR"/mongodb-connection-string
+echo -n "Enter the MongoDB host you noted down earlier: "
+read -r SECRETHUB_MONGODB_HOST
+echo "$SECRETHUB_MONGODB_HOST" | secrethub write "$COLLABORATOR_DIR"/mongodb-host
 
 echo -n "Enter the MongoDB developer password you noted down earlier: "
 read -r SECRETHUB_MONGODB_PASSWORD

--- a/scripts/add-mongodb-details-to-secrethub.sh
+++ b/scripts/add-mongodb-details-to-secrethub.sh
@@ -17,4 +17,4 @@ echo -n "Enter the MongoDB developer password you noted down earlier: "
 read -r SECRETHUB_MONGODB_PASSWORD
 echo "$SECRETHUB_MONGODB_PASSWORD" | secrethub write "$COLLABORATOR_DIR"/mongodb-password
 
-echo "Thanks, your MongoDB connection details should now be stored safely in SecretHub."
+echo "Thanks, if there were no errors above then your MongoDB connection details are now stored safely in SecretHub."

--- a/scripts/add-mongodb-details-to-secrethub.sh
+++ b/scripts/add-mongodb-details-to-secrethub.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script must be run from the project root directory
+
+echo -n "What is your SecretHub username? "
+read -r SECRETHUB_COLLABORATOR
+ORG_NAME=agilepathway
+REPO_NAME=british-prescription-data
+ORG_AND_REPO="$ORG_NAME"/"$REPO_NAME"
+COLLABORATOR_DIR="$ORG_AND_REPO"/"$SECRETHUB_COLLABORATOR"
+
+echo -n "Enter the MongoDB connection string you noted down earlier: "
+read -r SECRETHUB_MONGODB_CONNECTION_STRING
+echo "$SECRETHUB_MONGODB_CONNECTION_STRING" | secrethub write "$COLLABORATOR_DIR"/mongodb-connection-string
+
+echo -n "Enter the MongoDB developer password you noted down earlier: "
+read -r SECRETHUB_MONGODB_PASSWORD
+echo "$SECRETHUB_MONGODB_PASSWORD" | secrethub write "$COLLABORATOR_DIR"/mongodb-password
+
+echo "Thanks, your MongoDB connection details should now be stored safely in SecretHub."

--- a/scripts/admin/add-collaborator-to-secrethub-org.sh
+++ b/scripts/admin/add-collaborator-to-secrethub-org.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# You must be an administrator of the SecretHub org to run this script
+
+SECRETHUB_COLLABORATOR=$1
+ORG_NAME=agilepathway
+REPO_NAME=british-prescription-data
+ORG_AND_REPO="$ORG_NAME"/"$REPO_NAME"
+COLLABORATOR_DIR="$ORG_AND_REPO"/"$SECRETHUB_COLLABORATOR"
+
+if [[ -z "$SECRETHUB_COLLABORATOR" ]]; then
+  echo "You must provide the SecretHub username of the collaborator, e.g."
+  echo "    ./scripts/admin/add-collaborator-to-secrethub-org.sh the-username"
+  exit 1
+fi
+
+secrethub org invite "$ORG_NAME" "$SECRETHUB_COLLABORATOR"
+
+secrethub repo invite "$ORG_AND_REPO" "$SECRETHUB_COLLABORATOR"
+
+secrethub acl set "$ORG_AND_REPO"/prod "$SECRETHUB_COLLABORATOR" write
+
+secrethub mkdir "$COLLABORATOR_DIR"
+
+secrethub acl set "$COLLABORATOR_DIR" "$SECRETHUB_COLLABORATOR" write
+
+echo "$REPO_NAME" | secrethub write "$COLLABORATOR_DIR"/mongodb-db
+
+echo "$REPO_NAME" | secrethub write "$COLLABORATOR_DIR"/mongodb-collection
+
+echo "admin" | secrethub write "$COLLABORATOR_DIR"/mongodb-auth-db
+
+echo "developer" | secrethub write "$COLLABORATOR_DIR"/mongodb-username

--- a/scripts/admin/add-collaborator-to-secrethub-org.sh
+++ b/scripts/admin/add-collaborator-to-secrethub-org.sh
@@ -31,3 +31,5 @@ echo "$REPO_NAME" | secrethub write "$COLLABORATOR_DIR"/mongodb-collection
 echo "admin" | secrethub write "$COLLABORATOR_DIR"/mongodb-auth-db
 
 echo "developer" | secrethub write "$COLLABORATOR_DIR"/mongodb-username
+
+secrethub read "$ORG_AND_REPO"/prod/prescription-data-url | secrethub write "$COLLABORATOR_DIR"/prescription-data-url

--- a/scripts/import-prescription-data-to-mongodb.sh
+++ b/scripts/import-prescription-data-to-mongodb.sh
@@ -8,7 +8,7 @@ PRESCRIPTION_DATA_FILE_PATH=$PRESCRIPTION_DATA_DIR/prescription_data.json
 mkdir -p "$PRESCRIPTION_DATA_DIR" || exit 1
 curl -o "$PRESCRIPTION_DATA_FILE_PATH" "$PRESCRIPTION_DATA_URL" || exit 1
 
-mongoimport "$MONGODB_CONNECTION_STRING" \
+mongoimport "mongodb+srv://$MONGODB_HOST" \
     --db "$MONGODB_DB" \
     --collection "$MONGODB_COLLECTION" \
     --authenticationDatabase "$MONGODB_AUTH_DB" \

--- a/scripts/import-prescription-data-to-mongodb.sh
+++ b/scripts/import-prescription-data-to-mongodb.sh
@@ -8,4 +8,13 @@ PRESCRIPTION_DATA_FILE_PATH=$PRESCRIPTION_DATA_DIR/prescription_data.json
 mkdir -p "$PRESCRIPTION_DATA_DIR" || exit 1
 curl -o "$PRESCRIPTION_DATA_FILE_PATH" "$PRESCRIPTION_DATA_URL" || exit 1
 
-echo "Downloaded prescription data to $PRESCRIPTION_DATA_FILE_PATH"
+mongoimport "$MONGODB_CONNECTION_STRING" \
+    --db "$MONGODB_DB" \
+    --collection "$MONGODB_COLLECTION" \
+    --authenticationDatabase "$MONGODB_AUTH_DB" \
+    --username "$MONGODB_USERNAME" \
+    --password "$MONGODB_PASSWORD" \
+    --drop --file \
+    $PRESCRIPTION_DATA_FILE_PATH
+
+rm -rf $PRESCRIPTION_DATA_DIR

--- a/scripts/secrethub-wrapper.sh
+++ b/scripts/secrethub-wrapper.sh
@@ -7,7 +7,7 @@ if [[ -z "${SECRETHUB_USERNAME}" ]]; then
   read -r SECRETHUB_USERNAME
   echo "To avoid being prompted again, run:"
   echo "    export SECRETHUB_USERNAME=your_username"
-  echo "in the terminal."
+  echo "in the terminal, after this script has finished."
 fi
 
 secrethub run --var "user=$SECRETHUB_USERNAME" ./scripts/import-prescription-data-to-mongodb.sh

--- a/scripts/secrethub-wrapper.sh
+++ b/scripts/secrethub-wrapper.sh
@@ -10,4 +10,4 @@ if [[ -z "${SECRETHUB_USERNAME}" ]]; then
   echo "in the terminal, after this script has finished."
 fi
 
-secrethub run --var "user=$SECRETHUB_USERNAME" ./scripts/import-prescription-data-to-mongodb.sh
+secrethub run --var "env=$SECRETHUB_USERNAME" ./scripts/import-prescription-data-to-mongodb.sh

--- a/scripts/secrethub-wrapper.sh
+++ b/scripts/secrethub-wrapper.sh
@@ -2,4 +2,12 @@
 
 # This script must be run from the project root directory
 
-secrethub run --  ./scripts/download-prescription-data.sh
+if [[ -z "${SECRETHUB_USERNAME}" ]]; then
+  echo -n "What is your SecretHub username? "
+  read -r SECRETHUB_USERNAME
+  echo "To avoid being prompted again, run:"
+  echo "    export SECRETHUB_USERNAME=your_username"
+  echo "in the terminal."
+fi
+
+secrethub run --var "user=$SECRETHUB_USERNAME" ./scripts/import-prescription-data-to-mongodb.sh

--- a/secrethub.env
+++ b/secrethub.env
@@ -1,9 +1,9 @@
 # See https://secrethub.io/docs/guides/environment-variables/#create-secrethub-env-file
 
-PRESCRIPTION_DATA_URL = {{ agilepathway/british-prescription-data/prod/prescription-data-url }}
-MONGODB_HOST = {{ agilepathway/british-prescription-data/${user}/mongodb-host }}
-MONGODB_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-db }}
-MONGODB_AUTH_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-auth-db }}
-MONGODB_COLLECTION = {{ agilepathway/british-prescription-data/${user}/mongodb-collection }}
-MONGODB_USERNAME = {{ agilepathway/british-prescription-data/${user}/mongodb-username }}
-MONGODB_PASSWORD = {{ agilepathway/british-prescription-data/${user}/mongodb-password }}
+PRESCRIPTION_DATA_URL = {{ agilepathway/british-prescription-data/${env}/prescription-data-url }}
+MONGODB_HOST = {{ agilepathway/british-prescription-data/${env}/mongodb-host }}
+MONGODB_DB = {{ agilepathway/british-prescription-data/${env}/mongodb-db }}
+MONGODB_AUTH_DB = {{ agilepathway/british-prescription-data/${env}/mongodb-auth-db }}
+MONGODB_COLLECTION = {{ agilepathway/british-prescription-data/${env}/mongodb-collection }}
+MONGODB_USERNAME = {{ agilepathway/british-prescription-data/${env}/mongodb-username }}
+MONGODB_PASSWORD = {{ agilepathway/british-prescription-data/${env}/mongodb-password }}

--- a/secrethub.env
+++ b/secrethub.env
@@ -1,3 +1,9 @@
 # See https://secrethub.io/docs/guides/environment-variables/#create-secrethub-env-file
 
 PRESCRIPTION_DATA_URL = {{ agilepathway/british-prescription-data/prod/prescription-data-url }}
+MONGODB_CONNECTION_STRING = {{ agilepathway/british-prescription-data/${user}/mongodb-connection-string }}
+MONGODB_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-db }}
+MONGODB_AUTH_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-auth-db }}
+MONGODB_COLLECTION = {{ agilepathway/british-prescription-data/${user}/mongodb-collection }}
+MONGODB_USERNAME = {{ agilepathway/british-prescription-data/${user}/mongodb-username }}
+MONGODB_PASSWORD = {{ agilepathway/british-prescription-data/${user}/mongodb-password }}

--- a/secrethub.env
+++ b/secrethub.env
@@ -1,7 +1,7 @@
 # See https://secrethub.io/docs/guides/environment-variables/#create-secrethub-env-file
 
 PRESCRIPTION_DATA_URL = {{ agilepathway/british-prescription-data/prod/prescription-data-url }}
-MONGODB_CONNECTION_STRING = {{ agilepathway/british-prescription-data/${user}/mongodb-connection-string }}
+MONGODB_HOST = {{ agilepathway/british-prescription-data/${user}/mongodb-host }}
 MONGODB_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-db }}
 MONGODB_AUTH_DB = {{ agilepathway/british-prescription-data/${user}/mongodb-auth-db }}
 MONGODB_COLLECTION = {{ agilepathway/british-prescription-data/${user}/mongodb-collection }}


### PR DESCRIPTION

    
Our ultimate goal is to get the data into a [Kafka][1] data pipeline,
on [Confluent Cloud][2]. Confluent Cloud does not provide an out of the
box way of consuming JSON data (they instead require you to set up
additional infrastructure yourself). To avoid that overhead and to keep
things as simple as we can, we are using [MongoDB's Atlas cloud][3]
as our go-between for the JSON data and Kakfa. MongoDB is a good choice
of go-between as it:
    
1. [has an import tool which makes importing JSON easy][4]
2. [is a first-class connector on the Confluent Cloud platform][5],
which makes it straightforward to get the data from MongoDB into
Kafka.
    
[1]: https://kafka.apache.org/
[2]: https://www.confluent.io/confluent-cloud
[3]: https://www.mongodb.com/cloud/atlas
[4]: https://docs.mongodb.com/guides/server/import/
[5]: https://www.confluent.io/blog/confluent-cloud-offers-kafka-mongodb-connector-fully-managed-clusters/